### PR TITLE
Oppenent Information Plugin Fix

### DIFF
--- a/src/main/java/com/boss/health/indicator/BossHealthIndicatorPlugin.java
+++ b/src/main/java/com/boss/health/indicator/BossHealthIndicatorPlugin.java
@@ -132,7 +132,7 @@ public class BossHealthIndicatorPlugin extends Plugin
 			String[] numbers = bossHealthText.split(" / ");
 			try {
 				int numerator = Integer.parseInt(numbers[0]);
-				int denominator = Integer.parseInt(numbers[1]);
+				int denominator = Integer.parseInt(numbers[1].contains("%") ? (numbers[1].split(" "))[0] : numbers[1]);
 				double percentHealth = ((double)numerator) / denominator;
 				final boolean forceCheck = lastBossHealthPercentage == null || percentHealth > lastBossHealthPercentage;
 				if (forceCheck) {


### PR DESCRIPTION
Fixes an issue where the plugin doesn't notify when an indicator percentage is reached. The issue is when the Both option is enabled in the Oppenent Information plugin it displays both the number and percentage in the health bar. This would cause the Try/Catch statement to fire a warning when converting the denominator to an Integer.